### PR TITLE
Adds translation support

### DIFF
--- a/registered-users-only.php
+++ b/registered-users-only.php
@@ -40,11 +40,21 @@ class RegisteredUsersOnly {
 		add_action( 'wp', array( $this, 'MaybeRedirect' ) );
 		add_action( 'rest_api_init', array( $this, 'MaybeRedirect' ) );
 		add_action( 'init', array( $this, 'LoginFormMessage' ) );
+		add_action( 'init', array( $this, 'load_textdomain' );
 		add_action( 'admin_menu', array( $this, 'AddAdminMenu' ) );
 
 		if ( isset( $_POST['regusersonly_action'] ) && 'update' == $_POST['regusersonly_action'] ) {
 			add_action( 'init', array( $this, 'POSTHandle' ) );
 		}
+	}
+ 
+	/**
+	 * Loads the translations.
+	 *
+	 * @todo Remove when WordPress 4.6+ is the minimum version. Not needed for w.org-hosted plugins when using language packs.
+	 */
+	public function load_textdomain() {
+		load_plugin_textdomain( 'registered-users-only', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' ); 
 	}
 
 


### PR DESCRIPTION
Language packs aren't being created for this plugin because we're supporting older version of WordPress and not loading the plugin text domain (see https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/ )

Alternatively, we could reject this PR and bump the minimum supported version to WordPress 4.6. I think 4.6 is old enough now that we'd be fine doing that.