### PR TITLE
Added: Allow Authenticated users to access the Rest API

### DIFF
--- a/registered-users-only.php
+++ b/registered-users-only.php
@@ -81,6 +81,11 @@ class RegisteredUsersOnly {
 			return;
 		}
 
+		// Authenticated Rest 
+		if ( ! empty( $settings['rest_auth'] ) && $is_rest ) {
+			return;
+		}
+
 		// This is a base array of pages that will be EXCLUDED from being blocked
 		$this->exclusions = array(
 			'wp-login.php',
@@ -157,6 +162,7 @@ class RegisteredUsersOnly {
 		$settings = array(
 			'feeds' => ( ! empty( $_POST['regusersonly_feeds'] ) ) ? 1 : 0,
 			'rest'  => ( ! empty( $_POST['regusersonly_rest'] ) ) ? 1 : 0,
+			'rest_auth'  => ( ! empty( $_POST['regusersonly_rest_auth'] ) ) ? 1 : 0,
 		);
 
 		update_option( 'registered-users-only', $settings );
@@ -190,7 +196,11 @@ class RegisteredUsersOnly {
 								<input name="users_can_register" type="checkbox" id="users_can_register" value="1"<?php checked( '1', get_option( 'users_can_register' ) ); ?> />
 								<?php _e( 'Anyone can register' ) ?>
 							</label><br />
-							<?php _e( 'This is a default WordPress option placed here for easy changing.', 'registered-users-only' ); ?>
+							<?php _e( 'This is a default WordPress option placed here for easy changing.', 'registered-users-only' ); ?><br /><br />
+							<label for="regusersonly_rest_auth">
+								<input name="regusersonly_rest_auth" type="checkbox" id="regusersonly_rest_auth" value="1"<?php checked( '1', ! empty( $settings['rest_auth'] ) ); ?> />
+								<?php _e( 'Allow authenticated access to your REST APIs', 'registered-users-only' ); ?>
+							</label><br />
 						</td>
 					</tr>
 					<tr valign="top">

--- a/registered-users-only.php
+++ b/registered-users-only.php
@@ -105,6 +105,12 @@ class RegisteredUsersOnly {
 
 	// Allow authenticated users to access the rest API.
 	public function restrict_rest_api( $result ) {
+		$settings = get_option( 'registered-users-only' );
+
+		if ( ! empty( $settings['rest'] ) ) {
+			return $result;
+		}
+
 		// If a previous authentication check was applied,
 		// pass that result along without modification.
 		if ( true === $result || is_wp_error( $result ) ) {
@@ -123,8 +129,6 @@ class RegisteredUsersOnly {
 	
 		return $result;
 	}
-	
-
 
 	// Use some deprecate code (yeah, I know) to insert a "You must login" error message to the login form
 	// If this breaks in the future, oh well, it's just a pretty message for users


### PR DESCRIPTION
Currently, the only way to expose the rest API is to allow guest access. This PR adds the ability for registered users to access the REST API. 

This has been tested with WP's built in application passwords. 